### PR TITLE
Squash array subscript has type 'char' warnings.

### DIFF
--- a/src/functions.h
+++ b/src/functions.h
@@ -176,7 +176,7 @@ extern BOOL         string_read_plain(void);
 extern void         string_relativize(void);
 extern void         string_stavestring(BOOL);
 extern int32_t      string_width(uint32_t *, fontinststr *, int32_t *);
-extern int          strncmpic(const char*, const char *, int);
+extern int          strncmpic(const unsigned char*, const unsigned char *, int);
 
 extern uint32_t     transpose_key(uint32_t);
 extern int16_t      transpose_note(int16_t, int16_t *, uint8_t *, uint8_t,

--- a/src/main.c
+++ b/src/main.c
@@ -167,7 +167,7 @@ static debug_bit_table debug_options[] = {
 *************************************************/
 
 int
-strncmpic(const char *s, const char *t, int n)
+strncmpic(const unsigned char *s, const unsigned char *t, int n)
 {
 while (n--)
   {
@@ -208,7 +208,7 @@ for(;;)
 
   adding = *string++ == '+';
   s = string;
-  while (isalnum(*string) || *string == '_') string++;
+  while (isalnum((unsigned char)*string) || *string == '_') string++;
   len = string - s;
 
   start = debug_options;

--- a/src/pmw.h
+++ b/src/pmw.h
@@ -258,7 +258,7 @@ typedef uint8_t CBOOL;
 #define Ustrcpy(s,t)         strcpy(CS(s),CCS(t))
 #define Ustrlen(s)           (size_t)strlen(CCS(s))
 #define Ustrncmp(s,t,n)      strncmp(CCS(s),CCS(t),n)
-#define Ustrncmpic(s,t,n)    strncmpic(CCS(s),CCS(t),n)
+#define Ustrncmpic(s,t,n)    strncmpic(CUS(s),CUS(t),n)
 #define Ustrncpy(s,t,n)      strncpy(CS(s),CS(t),n)
 #define Ustrrchr(s,n)        US strrchr(CCS(s),n)
 #define Ustrstr(s, t)        US strstr(CS(s),CS(t))

--- a/src/rdargs.c
+++ b/src/rdargs.c
@@ -314,8 +314,8 @@ for (;;)
     {
     if ((argflags & rdargflag_n) != 0)
       {
-      if (!isdigit(nextstring[0]) &&
-        (nextstring[0] != '-' || !isdigit(nextstring[1]))) break;
+      if (!isdigit((unsigned char)nextstring[0]) &&
+        (nextstring[0] != '-' || !isdigit((unsigned char)nextstring[1]))) break;
       }
     else if (nextstring[0] == '-') break;
     }
@@ -393,7 +393,7 @@ while ((ch = keystring[++i]) != 0)
       }
 
     default:
-    if (isdigit(keystring[i]))
+    if (isdigit((unsigned char)keystring[i]))
       {
       argcount = keystring[i] - '0';
       if (argcount == 0) argcount = 1;

--- a/src/read.c
+++ b/src/read.c
@@ -230,7 +230,7 @@ char *sss = (char *)ss;
 if (map != NULL) *map = 0;
 if (slp != NULL) *slp = NULL;
 
-while (isdigit(*sss))
+while (isdigit((unsigned char)*sss))
   {
   long int s = strtol(sss, &sss, 0);
   long int t = s;


### PR DESCRIPTION
This is more of the unsigned/signed issue which started in issue https://github.com/PhilipHazel/pmw/issues/5

A detailed explanation is given by Roland Illig in https://stackoverflow.com/questions/9972359/warning-array-subscript-has-type-char

These were the warnings:
```
/usr/local/gcc/bin/gcc main.c
In file included from /usr/include/ctype.h:100,
                 from pmw.h:19,
                 from main.c:9:
main.c: In function 'strncmpic':
main.c:174:19: warning: array subscript has type 'char' [-Wchar-subscripts]
  174 |   int c = tolower(*s++) - tolower(*t++);
      |                   ^
main.c:174:35: warning: array subscript has type 'char' [-Wchar-subscripts]
  174 |   int c = tolower(*s++) - tolower(*t++);
      |                                   ^
main.c: In function 'decode_debug':
main.c:211:18: warning: array subscript has type 'char' [-Wchar-subscripts]
  211 |   while (isalnum(*string) || *string == '_') string++;
      |                  ^


/usr/local/gcc/bin/gcc rdargs.c
In file included from /usr/include/ctype.h:100,
                 from rdargs.c:102:
rdargs.c: In function 'arg_setup_values':
rdargs.c:317:30: warning: array subscript has type 'char' [-Wchar-subscripts]
  317 |       if (!isdigit(nextstring[0]) &&
      |                              ^
rdargs.c:318:53: warning: array subscript has type 'char' [-Wchar-subscripts]
  318 |         (nextstring[0] != '-' || !isdigit(nextstring[1]))) break;
      |                                                     ^
rdargs.c: In function 'rdargs':
rdargs.c:396:26: warning: array subscript has type 'char' [-Wchar-subscripts]
  396 |     if (isdigit(keystring[i]))
      |                          ^



/usr/local/gcc/bin/gcc read.c
In file included from /usr/include/ctype.h:100,
                 from pmw.h:19,
                 from read.c:9:
read.c: In function 'read_stavelist':
read.c:233:16: warning: array subscript has type 'char' [-Wchar-subscripts]
  233 | while (isdigit(*sss))
      |                ^
```
as found by gcc 15.0 compiled from yesterday's source on NetBSD.