### PR TITLE
Adding missing figured bass macros

### DIFF
--- a/doc/examples/ex68
+++ b/doc/examples/ex68
@@ -22,6 +22,7 @@ unfinished
 &M(FBN,&FBN) 
 &M(FBS,&FBS) 
 
+&M(2,&2) 
 &M(2s,&2s) 
 &M(3,&3) 
 &M(3f,&3f) 
@@ -49,23 +50,30 @@ unfinished
 &M(5csb,&5csb) [space 6]
 &M(5cpsb,&5cpsb)
 &M(5f,&5f)
+&M(5n,&5n)
 &M(5fb,&5fb)
 &M(5sb,&5sb)
 
 &M(6,&6)
 &M(6c,&6c)
 &M(6cp,&6cp)
+&M(6cpfb,&6cpfb)
 &M(6cp4,&6cp4)
 &M(64,&64)
+&M(64cp2,&64cp2)
+&M(64f,&64f)
 
 &M(64c,&64c)
 &M(64cp,&64cp)
 &M(642,&642)
 &M(65,&65)
+&M(65fb,&65fb)
 
 &M(6f,&6f)
 &M(6fb,&6fb)
+&M(6ffb,&6ffb)
 &M(6f4,&6f4)
+&M(6n4,&6n4)
 &M(6s4,&6s4)
 
 &M(6n,&6n)
@@ -75,24 +83,30 @@ unfinished
 &M(7,&7)
 &M(72f,&72f)
 &M(742,&742)
+&M(7s42,&7s42)
+&M(74f2,&74f2)
 
 &M(75,&75)
 &M(75c2,&75c2) [space 4]
 &M(75cp2,&75cp2)
 
 &M(7c,&7c)
+&M(7cp42,&7cp42)
 &M(7nb,&7nb)
 &M(7s,&7s)
 
 &M(7sb,&7sb)
 &M(7s3,&7s3)
+&M(7f5f,&7f5f)
+&M(7ffb,&7ffb)
 &M(7u,&7u)
 &M(7f,&7f)
 
+&M(8,&8)
 &M(86,&86)
+&M(9,&9)
 &M(95,&95)
 &M(97,&97)
 &M(9fsb,&9fsb)
 
 [endstave]
-

--- a/macros/FigBass
+++ b/macros/FigBass
@@ -34,6 +34,7 @@
 @ examples that I happened to be printing when I originally defined these, and
 @ they have been added to subsequently.
 
+*define 2    "&FBI\rm\2"&FBU
 *define 2s   "&FBI\rm\2\mf\\sc\zxv%"&FBU
 *define 3    "&FBI\rm\3"&FBU
 *define 3f   "&FBI\rm\3\mu\z~v'"&FBU
@@ -60,22 +61,30 @@
 @ This version uses a 5 and a +
 *define 5cpsb "&FBI\rm\5\mu\x~vyyy\135\"&FBU "&FBI\mu\z~%"/fb
 *define 5f   "&FBI\rm\5\mu\z~v'"&FBU
+*define 5n   "&FBI\rm\5\mf\\sc\zxv\mu\\40\"&FBU
 *define 5fb  "&FBI\rm\5"&FBU "\mu\z~v'"/fb
 *define 5sb  "&FBI\rm\5"&FBU "&FBI\mu\z~%"/fb
+*define 5nb  "&FBI\rm\5"&FBU "\mu\zxv\40\"/fb
 *define 6    "&FBI\rm\6"&FBU
 *define 6c   "&FBI\mf\s"&FBU
 @ This version uses a 6 and a rotated +
 *define 6cp  "&FBI\rm\6"&FBU "&FBI\mu\xxxz\32\\135\"/fb/rot26
+*define 6cpfb "&FBI\rm\6"&FBU "&FBI\mu\xxxz\32\\135\"/fb/rot26 "\mu\z~v'"/u10/fb
 *define 6cp4 "&FBI\rm\6"&FBU "&FBI\mu\xxxz\32\\135\"/fb/rot26"&FBI\rm\4"/fb/u10
 *define 64   "&FBI\rm\6"&FBU "&FBI\rm\4"/fb
 *define 64c  "&FBI\rm\6"&FBU "&FBI\mf\k"/fb
 @ This version built from a 4 and a +
 *define 64cp "&FBI\rm\6"&FBU "&FBI\rm\4\mu\yy\135\"/fb
+*define 64cp2 "&FBI\rm\6"&FBU "&FBI\rm\4\mu\yy\135\"/fb "&FBI\rm\2"/fb
+*define 64f  "&FBI\rm\6"&FBU "&FBI\rm\4\mu\z~v'"/fb
 *define 642  "&FBI\rm\6"&FBU "&FBI\rm\4"/fb "&FBI\rm\2"/fb
 *define 65   "&FBI\rm\6"&FBU "&FBI\rm\5"/fb
+*define 65fb "&FBI\rm\6"&FBU "&FBI\rm\5"/fb "\mu\z~v'"/fb
 *define 6f   "&FBI\rm\6\mu\z~v'"&FBU
 *define 6fb  "&FBI\rm\6"&FBU "\mu\z~v'"/fb
+*define 6ffb "&FBI\rm\6\mu\z~v'"&FBU "\mu\z~v'"/fb
 *define 6f4  "&FBI\rm\6\mu\z~v'"&FBU "&FBI\rm\4"/fb
+*define 6n4  "&FBI\rm\6\mu\z~\40\"&FBU "&FBI\rm\4"/fb
 *define 6n   "&FBI\rm\6\mu\z~\40\"&FBU
 *define 6s   "&FBI\rm\6\mu\z~%"&FBU
 *define 6sb  "&FBI\rm\6"&FBU "&FBI\mu\z~%"/fb
@@ -83,18 +92,25 @@
 *define 7    "&FBI\rm\7"&FBU
 *define 72f  "&FBI\rm\7"&FBU "&FBI\rm\2\mu\z~v'"/fb
 *define 742  "&FBI\rm\7"&FBU "&FBI\rm\4"/fb "&FBI\rm\2"/fb
+*define 7s42 "&FBI\rm\7\mu\z~%"&FBU "&FBI\rm\4"/fb "&FBI\rm\2"/fb
+*define 74f2 "&FBI\rm\7"&FBU "&FBI\rm\4\mu\z~v'"/fb "&FBI\rm\2"/fb
 *define 75   "&FBI\rm\7"&FBU "&FBI\rm\5"/fb
 *define 75c2 "&FBI\rm\7"&FBU "&FBI\mf\\179\"/fb "&FBI\rm\2"/fb
 @ This version uses a 5 and a +
 *define 75cp2 "&FBI\rm\7"&FBU "&FBI\rm\5\mu\x~vyyy\135\"/fb "&FBI\rm\2"/fb
 *define 7c   "&FBI\mf\j"&FBU
+*define 7cp42  "&FBI\rm\7\mu\x~vyyy\135\"&FBU "&FBI\rm\4"/fb "&FBI\rm\2"/fb
 *define 7nb  "&FBI\rm\7"&FBU "\mu\zxv\40\"/fb
 *define 7s   "&FBI\rm\7\mu\z~%"&FBU
 *define 7sb  "&FBI\rm\7"&FBU "&FBI\mu\z~%"/fb
 *define 7s3  "&FBI\rm\7\mu\z~%"&FBU "&FBI\rm\3"/fb
+*define 7f5f "&FBI\rm\7\mu\z~v'"&FBU "&FBI\rm\5\mu\z~v'"/fb
+*define 7ffb "&FBI\rm\7\mu\z~v'"&FBU "\mu\z~v'"/fb
 *define 7u   "&FBI\rm\7_"&FBU
 *define 7f   "&FBI\rm\7\mu\z~v'"&FBU
+*define 8    "&FBI\rm\8"&FBU
 *define 86   "&FBI\rm\8"&FBU "&FBI\rm\6"/fb
+*define 9    "&FBI\rm\9"&FBU
 *define 95   "&FBI\rm\9"&FBU "&FBI\rm\5"/fb
 *define 97   "&FBI\rm\9"&FBU "&FBI\rm\7"/fb
 *define 9fsb "&FBI\rm\9\mu\z~v'"&FBU "&FBI\mu\z~%"/fb

--- a/testing/misctests/FBass
+++ b/testing/misctests/FBass
@@ -6,21 +6,20 @@ fbsize 8
 systemgap 52
 
 [stave 1 bass 0]
-"ulay"/ul c &2s c &3 c &3f c &3n c |
+"ulay"/ul &2 c c &2s c &3 c &3f c &3n c |
 &4 c &42 c &43 c &4c2 c &4cp2 c |
 &4f c &4f3 c &4n2 c &4n3 c &4s c |
 
 &5 c &53 c &53s c &54 c &5c c &5cp c |
-&5csb c &5cpsb c &5f c &5fb c &5sb c |
-&6 c &6c c &6cp c &6cp4 c &64 c &64c c &64cp c |
-&642 c &65 c &6f c &6fb c |
-&6f4 c &6s4 c &6n c &6s c &6sb c |
+&5csb c &5cpsb c &5f c &5n c &5fb c &5sb c &5nb c |
+&6 c &6c c &6cp c &6cpfb c &6cp4 c &64 c &64c c &64cp c |
+&642 c &65 c &65fb & &6f c &6fb c &6ffb c |
+&6f4 c &64cp2 c &64f c &6n4 c &6s4 c &6n c &6s c &6sb c |
 
-&7 c &72f c &742 c &75 c &75c2 c &75cp2 c |
-&7c c &7nb c &7s c &7sb c &7s3 c &7u c &7f c |
-&86 c &95 c &97 c &9fsb c |
+&7 c &72f c &742 c &7s42 c &74f2 c &75 c &75c2 c &75cp2 c |
+&7c c &7cp42 c &7nb c &7s c &7sb c &7s3 c &7f5f c &7ffb c &7u c &7f c |
+&8 c &86 c &9 c &95 c &97 c &9fsb c |
 
 &FB(3) c &FB(3,4) c &FB(7,2,4) c |
 &FBF c &FBN c &FBS c |
 [endstave]
-


### PR DESCRIPTION
I am adding some more figured bass macros for combinations I have met during editing the period manuscripts.